### PR TITLE
Fix deprecated references for tools and brushes

### DIFF
--- a/source/faq.rst
+++ b/source/faq.rst
@@ -74,7 +74,7 @@ Single-player does not use a watchdog.
 How do I remove a tool/brush from the item I'm holding?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the ``/none`` command while holding the item.
+Use the ``/tool none`` or ``/brush none`` command while holding the item. These are both currently the same command, so it doesn't matter which one you pick.
 
 
 Why isn't sign text/chest contents/entities/etc working?

--- a/source/quickstart.rst
+++ b/source/quickstart.rst
@@ -77,7 +77,7 @@ Playing with brushes
     2. Turn on a stone brush of radius 5: ``/br sphere stone 5``
     3. Aim at ground not near you and right click to place large stone spheres.
     4. Make it so the brush only affects grass: ``/mask grass``
-    5. Instead of placing stone, let's place wool: ``/mat red_wool,green_wool``
+    5. Instead of placing stone, let's place wool: ``/material red_wool,green_wool``
     6. Right click more areas.
     7. Disable the brush: ``/brush none``
 

--- a/source/quickstart.rst
+++ b/source/quickstart.rst
@@ -79,7 +79,7 @@ Playing with brushes
     4. Make it so the brush only affects grass: ``/mask grass``
     5. Instead of placing stone, let's place wool: ``/mat red_wool,green_wool``
     6. Right click more areas.
-    7. Disable the brush: ``/none``
+    7. Disable the brush: ``/brush none``
 
 Continuing on...
 ================

--- a/source/usage/regions/selections.rst
+++ b/source/usage/regions/selections.rst
@@ -32,7 +32,7 @@ Selecting with the wand
 
 The most intuitive way to select a region is by using wand. To get the wand, use ``//wand`` (it is, by default, a wooden axe). **Left clicking** a block with the wand marks that block as the first corner of the cuboid you wish to select. A **right-click** chooses the second corner.
 
-You can bind the selection wand to a different item either by changing the :doc:`configuration <../../config>` or using the ``//selwand`` command. In this regard, it is a :doc:`tool <../tools/tools>`.
+You can bind the selection wand to a different item either by changing the :doc:`configuration <../../config>` or using the ``/tool selwand`` command. In this regard, it is a :doc:`tool <../tools/tools>`.
 
 Selecting at your own location
 ------------------------------

--- a/source/usage/tools/brushes.rst
+++ b/source/usage/tools/brushes.rst
@@ -1,7 +1,7 @@
 Brushes
 =======
 
-Brush tools are general more designed for building, sculpting, and painting than the general utility :doc:`tools <tools>`. Like the rest of the tools, they are bound to an item by using the command, and are activated by right-clicking (or left clicking, for those with two actions). They are unbound with the ``/none`` command.
+Brush tools are general more designed for building, sculpting, and painting than the general utility :doc:`tools <tools>`. Like the rest of the tools, they are bound to an item by using the command, and are activated by right-clicking (or left clicking, for those with two actions). They are unbound with the ``/brush none`` command.
 
 Brushes have a few unique settings available to them. Brushes allow you to choose a mask, size, pattern, and range. These allow fine-tuning how you build and paint.
 


### PR DESCRIPTION
Finishes out #5.

or rather, fixes #5, as github prefers.