### PR TITLE
Add a video tutorial to the selections page

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -33,6 +33,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.autosectionlabel',
+    'sphinxcontrib.yt'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/conf.py
+++ b/source/conf.py
@@ -33,7 +33,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.autosectionlabel',
-    'sphinxcontrib.yt'
+    'enginehub.sphinx_youtube'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinxcontrib.yt

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -1,2 +1,2 @@
 sphinx
-sphinxcontrib.yt
+enginehub.sphinx-youtube

--- a/source/usage/regions/selections.rst
+++ b/source/usage/regions/selections.rst
@@ -8,6 +8,7 @@ A fundamental part of WorldEdit is working with a selection or region. For examp
     :backlinks: none
     :depth: 1
 
+.. youtube:: lzB0l5ZJGH8
 
 .. include:: ../../cuitip.rst
 
@@ -218,8 +219,3 @@ Using the ``//sel <mode>`` command allows you to change between different shapes
 .. topic:: ``//sel convex``
 
     Left-click to select first point. All subsequent points are selected by right clicking. The selection is a convex hull encompassing all your selected points.
-
-Video Tutorial
-~~~~~~~~~~~~~~
-
-.. youtube:: lzB0l5ZJGH8

--- a/source/usage/regions/selections.rst
+++ b/source/usage/regions/selections.rst
@@ -218,3 +218,8 @@ Using the ``//sel <mode>`` command allows you to change between different shapes
 .. topic:: ``//sel convex``
 
     Left-click to select first point. All subsequent points are selected by right clicking. The selection is a convex hull encompassing all your selected points.
+
+Video Tutorial
+~~~~~~~~~~~~~~
+
+.. youtube:: lzB0l5ZJGH8


### PR DESCRIPTION
People always ask about video tutorials (proof people don't read smh) - so I've added YouTube embed support to the docs, as well as included the one tutorial I've made on the relevant page (can include more in the future if I make more)