### PR TITLE
fix: broken sonatype repo docs link 

### DIFF
--- a/source/api/index.rst
+++ b/source/api/index.rst
@@ -48,7 +48,7 @@ When developing, take note of :doc:`internal-apis` to ensure you're using suppor
 If you need the Javadocs, they are hosted at
 `<https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-core/7.3.0/>`_.
 
-.. _Maven repository: https://help.sonatype.com/en/repository-manager-concepts.html
+.. _Maven repository: https://maven.apache.org/repositories/layout.html
 .. _Maven: https://maven.apache.org/
 .. _Gradle: https://gradle.org/
 .. _sbt: https://www.scala-sbt.org/

--- a/source/api/index.rst
+++ b/source/api/index.rst
@@ -48,7 +48,7 @@ When developing, take note of :doc:`internal-apis` to ensure you're using suppor
 If you need the Javadocs, they are hosted at
 `<https://docs.enginehub.org/javadoc/com.sk89q.worldedit/worldedit-core/7.3.0/>`_.
 
-.. _Maven repository: https://help.sonatype.com/repomanager3/repository-manager-concepts/an-example---maven-repository-format
+.. _Maven repository: https://help.sonatype.com/en/repository-manager-concepts.html
 .. _Maven: https://maven.apache.org/
 .. _Gradle: https://gradle.org/
 .. _sbt: https://www.scala-sbt.org/


### PR DESCRIPTION
fixed a broken link for sonatype (https://help.sonatype.com/repomanager3/repository-manager-concepts/an-example---maven-repository-format)

![image](https://github.com/user-attachments/assets/43b3c175-6586-47a3-8c6b-fad2a401486f)

