### PR TITLE
Document Fabric Permission API limitations

### DIFF
--- a/source/permissions.rst
+++ b/source/permissions.rst
@@ -228,3 +228,10 @@ Other Permissions
     ``worldedit.setnbt``,"Allows setting `extra data <https://minecraft.wiki/w/Block_entity>`_ on blocks (such as signs, chests, etc)."
     ``worldedit.report.pastebin``,"Allows uploading report files to pastebin automatically for the ``/worldedit report`` :doc:`command <commands>`."
     ``worldedit.scripting.execute.<filename>``,"Allows using the CraftScript with the given filename."
+
+.. note::
+    Due to a limitation of the Fabric Permissions API, some filename permissions for ``worldedit.scripting.execute.<filename>`` need to be converted before use.
+
+    If your filename contains any uppercase letters, the permission must be done lowercase. For any non-alphanumerical characters other than ``-``, ``/``, and ``.``,
+    you must replace the character with ``_00`` where 00 is replaced by the "HEX" entry for that character on `this table <https://www.ascii-code.com/>`_. We hope this
+    limitation in Fabric can be resolved in the future to remove the need for this workaround.


### PR DESCRIPTION
Document the limitations of the Fabric Permissions API, as per https://github.com/EngineHub/WorldEdit/pull/2990

<img width="1252" height="439" alt="image" src="https://github.com/user-attachments/assets/6d7c4d84-207d-41f2-9119-0ed0d36bd9c0" />
